### PR TITLE
fix: add package-* to Makefile and systemd unit file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,19 @@ GOTEST=$(GOCMD) test
 GOMOD=$(GOCMD) mod
 BINARY_NAME=netbird-exporter
 DOCKER_TAG=gocloudio/netbird-exporter:latest
+# Packages parameters
+DIST_DIR      ?= dist/
+ARCH          ?= $(shell uname -m)
+VERSION       ?= $(shell git describe --abbrev --long HEAD)
+ABBREV        ?= $(shell git rev-parse --short HEAD)
+COMMIT        ?= $(shell git rev-parse HEAD)
+TAG           ?= $(shell git describe --tags --abbrev=0 HEAD)
+VERSION_PKG   ?= $(shell echo $(VERSION) | sed 's/^v//g')
+LICENSE       := MIT
+URL           := https://github.com/gocloudio/netbird-exporter
+DESCRIPTION   := A Prometheus exporter for NetBird peer metrics.
+DATE          :=  $(shell date +%FT%T%z)
+MAINTAINER    := dkrhodes@users.noreply.github.com
 
 all: test build
 
@@ -16,6 +29,10 @@ build:
 
 test:
 	$(GOTEST) -v ./...
+
+.PHONY: prepare
+prepare:
+	mkdir -p $(DIST_DIR)
 
 clean:
 	$(GOCLEAN)
@@ -37,4 +54,28 @@ build-linux:
 
 build-arm:
 	mkdir -p output	
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOBUILD) -o output/$(BINARY_NAME)-linux-arm64 -v ./cmd/netbird-exporter 
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOBUILD) -o output/$(BINARY_NAME)-linux-arm64 -v ./cmd/netbird-exporter
+
+.PHONY: package-deb
+package-deb: prepare
+	fpm -s dir -t deb -n $(BINARY_NAME) -v $(VERSION_PKG) \
+        --maintainer "$(MAINTAINER)" \
+        --description "$(DESCRIPTION)"  \
+        --url "$(URL)" \
+        --architecture $(ARCH) \
+        --license "$(LICENSE)" \
+        --package $(DIST_DIR) \
+        $(OUTPUT)=/usr/local/bin/netbird-exporter \
+        package/netbird-exporter.service=/lib/systemd/system/netbird-exporter.service
+
+.PHONY: package-rpm
+package-rpm: prepare
+	fpm -s dir -t rpm -n $(BINARY_NAME) -v $(VERSION_PKG) \
+        --maintainer "$(MAINTAINER)" \
+        --description "$(DESCRIPTION)" \
+        --url "$(URL)" \
+        --architecture $(ARCH) \
+        --license "$(LICENSE) "\
+        --package $(DIST_DIR) \
+        $(OUTPUT)=/usr/local/bin/netbird-exporter \
+        package/netbird-exporter.service=/lib/systemd/system/netbird-exporter.service

--- a/package/netbird-exporter.service
+++ b/package/netbird-exporter.service
@@ -1,0 +1,39 @@
+[Unit]
+Description=NetBird Exporter, A Prometheus exporter for NetBird peer metrics.
+After=network-online.target
+
+[Service]
+Type=simple
+User=netbird-exp
+Group=netbird-exp
+ExecStart=/usr/local/bin/netbird-exporter \
+    '--web.listen-address=localhost:9101'
+Restart=always
+RestartSec=1
+StartLimitInterval=0
+
+ProtectHome=yes
+NoNewPrivileges=yes
+PrivateTmp=true
+UMask=077
+
+ProtectSystem=strict
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=yes
+
+IPAccounting=yes
+IPAddressAllow=localhost link-local multicast 10.0.0.0/8 192.168.0.0/16
+
+SystemCallFilter=~@clock @cpu-emulation @debug @mount @obsolete @privileged @raw-io @reboot @resources @swap @module
+SystemCallArchitectures=native
+# When system call is disallowed, return error code instead of killing process
+SystemCallErrorNumber=EPERM
+
+CPUWeight=80
+CPUQuota=40%
+MemoryMax=2G
+IOWeight=80
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Follow-up of https://github.com/gocloudio/netbird-exporter/pull/2

If I remember correctly, this was inspired from https://github.com/netsampler/goflow2/blob/main/Makefile & https://github.com/netsampler/goflow2/blob/main/.github/workflows/main.yml
Added some elements but not tested as in the end, I didn't use netbird anymore.